### PR TITLE
Added install target for memorymap binary

### DIFF
--- a/app/app.pro
+++ b/app/app.pro
@@ -7,3 +7,10 @@ TARGET = memorymap
 DESTDIR = ../bin/
 
 SOURCES += main.cpp
+
+isEmpty(PREFIX) {
+    PREFIX = /usr/local
+}
+
+target.path = $$PREFIX/bin
+INSTALLS += target


### PR DESCRIPTION
This adds an install target to the generated Makefile. The install target is used by the flatpak builder to place the binary in the right location in the flatpak.